### PR TITLE
update to OTS v8.1.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [download]
 ; OpenType Sanitizer version that is downloaded from setup.py
-version = 8.1.0
+version = 8.1.1
 ; expected SHA-256 of the downloaded tarball. E.g. you can calculate it with:
 ; $ shasum -a 256 ots-X.X.X.tar.xz
-sha256 = e87cb5c18962e3b94b7ee27ab66fee9fdb22b12a9e06de9ecc3ef4f6990cefba
+sha256 = 8b912fae494228c5e308225ff15d1aaaf026587661c3c2d20676adb28795ff48
 
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
OTS has been updated to v8.1.1 recently: https://github.com/khaledhosny/ots/commit/d6d783c67b4aa604edd12dce0decc18a5c79906b

This PR updates the `setup.cfg` to reflect this change.

After this PR is merged, a new release tag has to be created by the maintainer in order to be able to download the v8.1.1 release tar directly from Github.